### PR TITLE
Implement parse bracketgeometry

### DIFF
--- a/mxml.xcodeproj/project.pbxproj
+++ b/mxml.xcodeproj/project.pbxproj
@@ -205,6 +205,10 @@
 		61F073CF1A71CEF5002CA9CA /* EndingGeometryFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F073CD1A71CEF5002CA9CA /* EndingGeometryFactory.h */; };
 		61F074241A72C676002CA9CA /* PageScoreGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 61F074221A72C676002CA9CA /* PageScoreGeometry.cpp */; };
 		61F074251A72C676002CA9CA /* PageScoreGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 61F074231A72C676002CA9CA /* PageScoreGeometry.h */; };
+		DD5A4BA1202ACDCF0049F021 /* BracketGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD5A4B9F202ACDCE0049F021 /* BracketGeometry.cpp */; };
+		DD5A4BA2202ACDCF0049F021 /* BracketGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD5A4B9F202ACDCE0049F021 /* BracketGeometry.cpp */; };
+		DD5A4BA3202ACDCF0049F021 /* BracketGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = DD5A4BA0202ACDCE0049F021 /* BracketGeometry.h */; };
+		DD5A4BA5202ACE2C0049F021 /* Bracket.h in Headers */ = {isa = PBXBuildFile; fileRef = DD5A4BA4202ACE2C0049F021 /* Bracket.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -579,6 +583,9 @@
 		61F073CD1A71CEF5002CA9CA /* EndingGeometryFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EndingGeometryFactory.h; sourceTree = "<group>"; };
 		61F074221A72C676002CA9CA /* PageScoreGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageScoreGeometry.cpp; sourceTree = "<group>"; };
 		61F074231A72C676002CA9CA /* PageScoreGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageScoreGeometry.h; sourceTree = "<group>"; };
+		DD5A4B9F202ACDCE0049F021 /* BracketGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BracketGeometry.cpp; sourceTree = "<group>"; };
+		DD5A4BA0202ACDCE0049F021 /* BracketGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BracketGeometry.h; sourceTree = "<group>"; };
+		DD5A4BA4202ACE2C0049F021 /* Bracket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bracket.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -766,6 +773,7 @@
 				614055FC1A5C6228005224C9 /* Types.h */,
 				614055FD1A5C6228005224C9 /* Unpitched.h */,
 				614055FE1A5C6228005224C9 /* Wedge.h */,
+				DD5A4BA4202ACE2C0049F021 /* Bracket.h */,
 			);
 			path = dom;
 			sourceTree = "<group>";
@@ -841,6 +849,8 @@
 				00094EF81A6746340053C615 /* WordsGeometry.h */,
 				61F074221A72C676002CA9CA /* PageScoreGeometry.cpp */,
 				61F074231A72C676002CA9CA /* PageScoreGeometry.h */,
+				DD5A4B9F202ACDCE0049F021 /* BracketGeometry.cpp */,
+				DD5A4BA0202ACDCE0049F021 /* BracketGeometry.h */,
 			);
 			path = geometry;
 			sourceTree = "<group>";
@@ -1075,8 +1085,10 @@
 				61F073CF1A71CEF5002CA9CA /* EndingGeometryFactory.h in Headers */,
 				61F072EA1A6F1183002CA9CA /* GenericNodeHandler.h in Headers */,
 				61C8508D1A6EE64300031100 /* SystemLayoutHandler.h in Headers */,
+				DD5A4BA5202ACE2C0049F021 /* Bracket.h in Headers */,
 				61A2B75F1A8E870000C1EE2A /* AlterSequence.h in Headers */,
 				61A81C741AAE3C9200E230A6 /* TimeModificationHandler.h in Headers */,
+				DD5A4BA3202ACDCF0049F021 /* BracketGeometry.h in Headers */,
 				61F072EE1A6F1BEE002CA9CA /* FormattedTextHandler.h in Headers */,
 				619AC7A01AA149C2005DFBED /* StemDirectionResolver.h in Headers */,
 				61C850581A6D838500031100 /* OctaveShiftGeometry.h in Headers */,
@@ -1266,6 +1278,7 @@
 				61A2B7641A8E870000C1EE2A /* DivisionsSequence.cpp in Sources */,
 				614057031A5C6228005224C9 /* PartGeometry.cpp in Sources */,
 				61F073CA1A71CD8F002CA9CA /* TieGeometryFactory.cpp in Sources */,
+				DD5A4BA1202ACDCF0049F021 /* BracketGeometry.cpp in Sources */,
 				61F072ED1A6F1BEE002CA9CA /* FormattedTextHandler.cpp in Sources */,
 				614056B91A5C6228005224C9 /* Measure.cpp in Sources */,
 				0022ADFD1A7082C300139992 /* CollisionHandler.cpp in Sources */,
@@ -1327,6 +1340,7 @@
 			files = (
 				61E530BD1A79A43700E5B2FF /* AlgorithmTests.cpp in Sources */,
 				614057901A5C625A005224C9 /* ParsingTests.cpp in Sources */,
+				DD5A4BA2202ACDCF0049F021 /* BracketGeometry.cpp in Sources */,
 				614057C01A5CAA47005224C9 /* ScorePropertiesTests.cpp in Sources */,
 				614057BE1A5C79EF005224C9 /* KeyTests.cpp in Sources */,
 				6140578F1A5C625A005224C9 /* NoteTests.cpp in Sources */,

--- a/src/mxml/dom/Bracket.h
+++ b/src/mxml/dom/Bracket.h
@@ -1,10 +1,8 @@
+// Copyright © 2016 Venture Media Labs.
 //
-//  Bracket.h
-//  pianomarvel
-//
-//  Created by nhatlee on 2/6/18.
-//  Copyright © 2018 nhatlee. All rights reserved.
-//
+// This file is part of mxml. The full mxml copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
 
 #pragma once
 #include "DirectionType.h"

--- a/src/mxml/dom/Bracket.h
+++ b/src/mxml/dom/Bracket.h
@@ -1,0 +1,59 @@
+//
+//  Bracket.h
+//  pianomarvel
+//
+//  Created by nhatlee on 2/6/18.
+//  Copyright © 2018 nhatlee. All rights reserved.
+//
+
+#pragma once
+#include "DirectionType.h"
+#include "Optional.h"
+#include "Types.h"
+
+namespace mxml {
+    namespace dom {
+        
+        class Bracket : public DirectionType {
+        public:
+            Bracket() : _type(kStart), _line(false), _sign(true) {}
+            
+            bool span() const {
+                return true;
+            }
+            
+            StartStopContinue type() const {
+                return _type;
+            }
+            void setType(StartStopContinue type) {
+                _type = type;
+            }
+            
+            bool line() const {
+                if (_line.isPresent())
+                    return _line.value();
+                return _sign.isPresent() && !_sign.value();
+            }
+            
+            void setLine(const Optional<bool>& line) {
+                _line = line;
+            }
+            
+            bool sign() const {
+                if (_sign.isPresent())
+                    return _sign;
+                return !_line.isPresent() || !_line.value();
+            }
+            
+            void setSign(const Optional<bool>& sign) {
+                _sign = sign;
+            }
+            
+        private:
+            StartStopContinue _type;
+            Optional<bool> _line;
+            Optional<bool> _sign;
+        };
+        
+    } // namespace dom
+} // namespace mxml

--- a/src/mxml/geometry/BracketGeometry.cpp
+++ b/src/mxml/geometry/BracketGeometry.cpp
@@ -1,10 +1,8 @@
+// Copyright © 2016 Venture Media Labs.
 //
-//  BracketGeometry.cpp
-//  pianomarvel
-//
-//  Created by nhatlee on 2/6/18.
-//  Copyright © 2018 nhatlee. All rights reserved.
-//
+// This file is part of mxml. The full mxml copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
 
 #include "BracketGeometry.h"
 #include <cassert>

--- a/src/mxml/geometry/BracketGeometry.cpp
+++ b/src/mxml/geometry/BracketGeometry.cpp
@@ -1,0 +1,39 @@
+//
+//  BracketGeometry.cpp
+//  pianomarvel
+//
+//  Created by nhatlee on 2/6/18.
+//  Copyright © 2018 nhatlee. All rights reserved.
+//
+
+#include "BracketGeometry.h"
+#include <cassert>
+
+
+namespace mxml {
+    
+    const Size BracketGeometry::kPedSize = {30, 20};
+    const Size BracketGeometry::kStarSize = {15, 15};
+    
+    BracketGeometry::BracketGeometry(const dom::Direction* start, const Point& startLocation, const dom::Direction* stop, const Point& stopLocation)
+    : SpanDirectionGeometry(start, startLocation, stop, stopLocation)
+    {
+        Size size = Geometry::size();
+        
+        const dom::DirectionType* type = nullptr;
+        if (start)
+            type = start->type();
+        else if (stop)
+            type = stop->type();
+        
+        const dom::Bracket* bracket = dynamic_cast<const dom::Bracket*>(type);
+        if (bracket->sign())
+            size.width = std::max(size.width, kPedSize.width + kStarSize.width);
+        else
+            size.width = std::max(size.width, kPedSize.width + 2);
+        size.height = kPedSize.height;
+        setSize(size);
+    }
+
+    
+} // namespace mxml

--- a/src/mxml/geometry/BracketGeometry.h
+++ b/src/mxml/geometry/BracketGeometry.h
@@ -1,10 +1,8 @@
+// Copyright © 2016 Venture Media Labs.
 //
-//  BracketGeometry.hpp
-//  pianomarvel
-//
-//  Created by nhatlee on 2/6/18.
-//  Copyright © 2018 nhatlee. All rights reserved.
-//
+// This file is part of mxml. The full mxml copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
 
 #pragma once
 #include <mxml/dom/Bracket.h>

--- a/src/mxml/geometry/BracketGeometry.h
+++ b/src/mxml/geometry/BracketGeometry.h
@@ -1,0 +1,23 @@
+//
+//  BracketGeometry.hpp
+//  pianomarvel
+//
+//  Created by nhatlee on 2/6/18.
+//  Copyright © 2018 nhatlee. All rights reserved.
+//
+
+#pragma once
+#include <mxml/dom/Bracket.h>
+#include "SpanDirectionGeometry.h"
+
+namespace mxml {
+    
+    class BracketGeometry : public SpanDirectionGeometry {
+    public:
+        static const Size kPedSize;
+        static const Size kStarSize;
+    public:
+        BracketGeometry(const dom::Direction* start, const Point& startLocation, const dom::Direction* stop, const Point& stopLocation);
+    };
+    
+} // namespace mxml

--- a/src/mxml/geometry/MeasureGeometry.h
+++ b/src/mxml/geometry/MeasureGeometry.h
@@ -45,6 +45,10 @@ public:
         return _showNumber;
     }
     
+    const ScoreProperties& scoreProperties() const {
+        return _scoreProperties;
+    }
+    
 private:
     const dom::Measure& _measure;
     const SpanCollection& _spans;

--- a/src/mxml/geometry/factories/DirectionGeometryFactory.h
+++ b/src/mxml/geometry/factories/DirectionGeometryFactory.h
@@ -55,6 +55,10 @@ private:
     void buildWords(const MeasureGeometry&  measureGeom, const dom::Direction& direction);
     void buildSegno(const MeasureGeometry&  measureGeom, const dom::Direction& direction);
     void buildCoda(const MeasureGeometry&  measureGeom, const dom::Direction& direction);
+    
+    void buildBracket(const MeasureGeometry&  measureGeom, const dom::Direction& direction);
+    void buildBracketToEdge(const dom::Direction& startDirection, const MeasureGeometry& stopMeasureGeom, const dom::Direction& stopDirection, bool isPage);
+
 
     Point spanOffsetInParentGeometry(const MeasureGeometry& measureGeometry, Point p);
     void placeDirection(PlacementGeometry& geometry);

--- a/src/mxml/parsing/DirectionTypeHandler.cpp
+++ b/src/mxml/parsing/DirectionTypeHandler.cpp
@@ -21,6 +21,7 @@ using dom::Pedal;
 using dom::Wedge;
 using dom::Words;
 using lxml::QName;
+using dom::Bracket;
 
 static const char* kTypeAttribute = "type";
 static const char* kNumberAttribute = "number";
@@ -35,6 +36,8 @@ static const char* kWordsTag = "words";
 static const char* kSegnoTag = "segno";
 static const char* kCodaTag = "coda";
 static const char* kOctaveShiftTag = "octave-shift";
+static const char* kBracketTag = "bracket";
+
 
 void DynamicsHandler::startElement(const QName& qname, const AttributeMap& attributes) {
     _result.reset(new Dynamics{});
@@ -69,6 +72,14 @@ lxml::RecursiveHandler* DynamicsHandler::startSubElement(const QName& qname) {
     if (valid)
         _result->setString(qname.localName());
     return 0;
+}
+    
+void BracketHandler::startElement(const QName& qname, const AttributeMap& attributes) {
+        using dom::presentOptional;
+        using lxml::DoubleHandler;
+        using lxml::StringHandler;
+        _result.reset(new Bracket{});
+        _result->position = PositionFactory::buildFromAttributes(attributes);
 }
 
 
@@ -170,6 +181,8 @@ lxml::RecursiveHandler* DirectionTypeHandler::startSubElement(const QName& qname
         return &_codaHandler;
     else if (strcmp(qname.localName(), kOctaveShiftTag) == 0)
         return &_octaveShiftHandler;
+    else if (strcmp(qname.localName(), kBracketTag) == 0)
+        return &_bracketHandler;
     return 0;
 }
 
@@ -188,6 +201,8 @@ void DirectionTypeHandler::endSubElement(const QName& qname, RecursiveHandler* p
         _result = _codaHandler.result();
     else if (strcmp(qname.localName(), kOctaveShiftTag) == 0)
         _result = _octaveShiftHandler.result();
+    else if (strcmp(qname.localName(), kBracketTag) == 0)
+        _result = _bracketHandler.result();
 }
 
 } // namespace mxml

--- a/src/mxml/parsing/DirectionTypeHandler.h
+++ b/src/mxml/parsing/DirectionTypeHandler.h
@@ -9,6 +9,7 @@
 #include <mxml/dom/Types.h>
 #include <mxml/dom/Pedal.h>
 #include <mxml/dom/Wedge.h>
+#include <mxml/dom/Bracket.h>
 
 #include <lxml/BaseRecursiveHandler.h>
 #include <lxml/DoubleHandler.h>
@@ -65,6 +66,13 @@ public:
     }
 };
 
+class BracketHandler: public lxml::BaseRecursiveHandler<std::unique_ptr<dom::Bracket>> {
+    public:
+        void startElement(const lxml::QName& qname, const AttributeMap& attributes);
+        static dom::StartStopContinue typeFromString(const std::string& string);
+};
+
+
 class DirectionTypeHandler : public lxml::BaseRecursiveHandler<std::unique_ptr<dom::DirectionType>> {
 public:
     void startElement(const lxml::QName& qname, const AttributeMap& attributes);
@@ -80,6 +88,7 @@ private:
     SegnoHandler _segnoHandler;
     CodaHandler _codaHandler;
     OctaveShiftHandler _octaveShiftHandler;
+    BracketHandler _bracketHandler;
 };
 
 } // namespace mxml


### PR DESCRIPTION
Currently into the `XML` file have info of bracket: ```<direction-type>
          <bracket default-y="-73" line-end="none" line-type="solid" number="1" type="start"/>
        </direction-type>```. But the library not parse this info yet. So I make this pull request to parse it.