### PR TITLE
Tie rendering in ScrollScoreLayout

### DIFF
--- a/mxml.xcodeproj/project.pbxproj
+++ b/mxml.xcodeproj/project.pbxproj
@@ -577,7 +577,7 @@
 		61F073B51A71CD8F002CA9CA /* OrnamentGeometryFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrnamentGeometryFactory.h; sourceTree = "<group>"; };
 		61F073B61A71CD8F002CA9CA /* PartGeometryFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PartGeometryFactory.cpp; sourceTree = "<group>"; };
 		61F073B71A71CD8F002CA9CA /* PartGeometryFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PartGeometryFactory.h; sourceTree = "<group>"; };
-		61F073BC1A71CD8F002CA9CA /* TieGeometryFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TieGeometryFactory.cpp; sourceTree = "<group>"; };
+		61F073BC1A71CD8F002CA9CA /* TieGeometryFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TieGeometryFactory.cpp; sourceTree = "<group>"; tabWidth = 4; };
 		61F073BD1A71CD8F002CA9CA /* TieGeometryFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TieGeometryFactory.h; sourceTree = "<group>"; };
 		61F073CC1A71CEF5002CA9CA /* EndingGeometryFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EndingGeometryFactory.cpp; sourceTree = "<group>"; };
 		61F073CD1A71CEF5002CA9CA /* EndingGeometryFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EndingGeometryFactory.h; sourceTree = "<group>"; };

--- a/mxml.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/mxml.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/mxml/Metrics.h
+++ b/src/mxml/Metrics.h
@@ -26,6 +26,10 @@ public:
     const dom::Score& score() const {
         return _score;
     }
+    
+    const ScoreProperties& scoreProperties() const {
+        return _scoreProperties;
+    }
 
     std::size_t partIndex() const {
         return _partIndex;

--- a/src/mxml/geometry/factories/DirectionGeometryFactory.cpp
+++ b/src/mxml/geometry/factories/DirectionGeometryFactory.cpp
@@ -62,16 +62,16 @@ std::vector<std::unique_ptr<PlacementGeometry>> DirectionGeometryFactory::build(
     for (auto& pair : _openSpanDirections) {
         auto measureGeometry = pair.first;
         auto direction = pair.second;
-        if (dynamic_cast<const dom::OctaveShift*>(direction->type())) {
+        if (dynamic_cast<const dom::OctaveShift*>(direction->type()) && _metrics->scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
             buildOctaveShiftToEdge(*measureGeometry, *direction);
         } else if (dynamic_cast<const dom::Pedal*>(direction->type())) {
             buildPedalToEdge(*measureGeometry, *direction);
         }
     }
-
+    
     // Build directions that neither started or stopped
     for (auto& direction : _previouslyOpenSpanDirections) {
-        if (dynamic_cast<const dom::OctaveShift*>(direction->type())) {
+        if (dynamic_cast<const dom::OctaveShift*>(direction->type()) && _metrics->scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
             buildOctaveShiftFromEdgeToEdge(*direction);
         } else if (dynamic_cast<const dom::Pedal*>(direction->type())) {
             buildPedalFromEdgeToEdge(*direction);

--- a/src/mxml/geometry/factories/TieGeometryFactory.cpp
+++ b/src/mxml/geometry/factories/TieGeometryFactory.cpp
@@ -15,403 +15,403 @@
 #include <mxml/Metrics.h>
 
 namespace mxml {
-
-TieGeometryFactory::TieGeometryFactory(const Geometry& parentGeometry, const Metrics& metrics)
-: _parentGeometry(parentGeometry),
-  _metrics(metrics)
-{
-}
-
-std::vector<std::unique_ptr<TieGeometry>>&& TieGeometryFactory::buildTieGeometries(const std::vector<std::unique_ptr<Geometry>>& geometries) {
-    _tieGeometries.clear();
-    _tieStartGeometries.clear();
-    _slurStartGeometries.clear();
-    createGeometries(geometries);
-
-    if (_metrics.scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
-        // Finish any ties that started but did not stop
-        for (auto& pair : _tieStartGeometries) {
-            auto tie = pair.second.first;
-            auto startGeom = pair.second.second;
-            auto tieGeom = buildTieGeometryToEdge(startGeom, tie->placement());
-            startGeom->setTieGeometry(tieGeom.get());
-            _tieGeometries.push_back(std::move(tieGeom));
+    
+    TieGeometryFactory::TieGeometryFactory(const Geometry& parentGeometry, const Metrics& metrics)
+    : _parentGeometry(parentGeometry),
+    _metrics(metrics)
+    {
+    }
+    
+    std::vector<std::unique_ptr<TieGeometry>>&& TieGeometryFactory::buildTieGeometries(const std::vector<std::unique_ptr<Geometry>>& geometries) {
+        _tieGeometries.clear();
+        _tieStartGeometries.clear();
+        _slurStartGeometries.clear();
+        createGeometries(geometries);
+        
+        if (_metrics.scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
+            // Finish any ties that started but did not stop
+            for (auto& pair : _tieStartGeometries) {
+                auto tie = pair.second.first;
+                auto startGeom = pair.second.second;
+                auto tieGeom = buildTieGeometryToEdge(startGeom, tie->placement());
+                startGeom->setTieGeometry(tieGeom.get());
+                _tieGeometries.push_back(std::move(tieGeom));
+            }
+            
+            // Finish any slurs that started but did not stop
+            for (auto& pair : _slurStartGeometries) {
+                auto slur = pair.second.first;
+                auto startGeom = pair.second.second;
+                auto slurGeom = buildSlurGeometryToEdge(startGeom, slur->placement());
+                startGeom->setTieGeometry(slurGeom.get());
+                _tieGeometries.push_back(std::move(slurGeom));
+            }
         }
         
-        // Finish any slurs that started but did not stop
-        for (auto& pair : _slurStartGeometries) {
-            auto slur = pair.second.first;
-            auto startGeom = pair.second.second;
-            auto slurGeom = buildSlurGeometryToEdge(startGeom, slur->placement());
+        return std::move(_tieGeometries);
+    }
+    
+    void TieGeometryFactory::createGeometries(const std::vector<std::unique_ptr<Geometry>>& geometries) {
+        for (auto& geom : geometries) {
+            if (auto measure = dynamic_cast<MeasureGeometry*>(geom.get())) {
+                createGeometries(measure->geometries());
+            } else if (auto chordGeom = dynamic_cast<ChordGeometry*>(geom.get())) {
+                createGeometriesFromChord(chordGeom);
+            } else if (auto noteGeom = dynamic_cast<NoteGeometry*>(geom.get())) {
+                createGeometryFromNote(noteGeom);
+            }
+        }
+    }
+    
+    void TieGeometryFactory::createGeometriesFromChord(ChordGeometry* chord) {
+        for (auto& note : chord->notes()) {
+            createGeometryFromNote(note);
+        }
+    }
+    
+    void TieGeometryFactory::createGeometryFromNote(NoteGeometry* noteGeometry) {
+        const dom::Note& note = noteGeometry->note();
+        if (!note.notations)
+            return;
+        
+        const auto& notations = note.notations;
+        
+        // Build ties
+        for (auto& tie : notations->ties) {
+            auto key = std::make_pair(note.staff(), note.pitch.get());
+            if (tie->type() == dom::kStart) {
+                _tieStartGeometries[key] = {tie.get(), noteGeometry};
+            } else if (tie->type() == dom::kContinue) {
+                buildTieGeometry(key, *noteGeometry, *tie);
+                _tieStartGeometries[key] = {tie.get(), noteGeometry};
+            } else if (tie->type() == dom::kStop) {
+                buildTieGeometry(key, *noteGeometry, *tie);
+            }
+        }
+        
+        // Build slurs
+        for (auto& slur : notations->slurs) {
+            auto key = std::make_pair(note.staff(), slur->number());
+            if (slur->type() == dom::kStart) {
+                _slurStartGeometries[key] = {slur.get(), noteGeometry};
+            } else if (slur->type() == dom::kContinue) {
+                buildSlurGeometry(key, *noteGeometry, *slur);
+                _slurStartGeometries[key] = {slur.get(), noteGeometry};
+            } else if (slur->type() == dom::kStop) {
+                buildSlurGeometry(key, *noteGeometry, *slur);
+            }
+        }
+    }
+    
+    void TieGeometryFactory::buildTieGeometry(const PitchKey& key, NoteGeometry& noteGeometry, const dom::Tied& tie) {
+        auto it = _tieStartGeometries.find(key);
+        auto startGeom = it->second.second;
+        
+        std::unique_ptr<TieGeometry> tieGeom;
+        if (it == _tieStartGeometries.end()) {
+            if (_metrics.scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
+                tieGeom = buildTieGeometryFromEdge(&noteGeometry, tie.placement());
+            } else {
+                return;
+            }
+        } else {
+            tieGeom = buildTieGeometry(startGeom, &noteGeometry, tie.placement());
+            startGeom->setTieGeometry(tieGeom.get());
+            _tieStartGeometries.erase(it);
+        }
+        noteGeometry.setTieGeometry(tieGeom.get());
+        _tieGeometries.push_back(std::move(tieGeom));
+    }
+    
+    void TieGeometryFactory::buildSlurGeometry(const SlurKey& key, NoteGeometry& noteGeometry, const dom::Slur& slur) {
+        auto it = _slurStartGeometries.find(key);
+        auto startGeom = it->second.second;
+        
+        std::unique_ptr<TieGeometry> slurGeom;
+        if (it == _slurStartGeometries.end()) {
+            if (_metrics.scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
+                slurGeom = buildSlurGeometryFromEdge(&noteGeometry, slur.placement());
+            } else {
+                return;
+            }
+        } else {
+            slurGeom = buildSlurGeometry(startGeom, &noteGeometry, slur.placement());
             startGeom->setTieGeometry(slurGeom.get());
-            _tieGeometries.push_back(std::move(slurGeom));
+            _slurStartGeometries.erase(it);
         }
+        noteGeometry.setTieGeometry(slurGeom.get());
+        _tieGeometries.push_back(std::move(slurGeom));
     }
-
-    return std::move(_tieGeometries);
-}
-
-void TieGeometryFactory::createGeometries(const std::vector<std::unique_ptr<Geometry>>& geometries) {
-    for (auto& geom : geometries) {
-        if (auto measure = dynamic_cast<MeasureGeometry*>(geom.get())) {
-            createGeometries(measure->geometries());
-        } else if (auto chordGeom = dynamic_cast<ChordGeometry*>(geom.get())) {
-            createGeometriesFromChord(chordGeom);
-        } else if (auto noteGeom = dynamic_cast<NoteGeometry*>(geom.get())) {
-            createGeometryFromNote(noteGeom);
-        }
-    }
-}
-
-void TieGeometryFactory::createGeometriesFromChord(ChordGeometry* chord) {
-    for (auto& note : chord->notes()) {
-        createGeometryFromNote(note);
-    }
-}
-
-void TieGeometryFactory::createGeometryFromNote(NoteGeometry* noteGeometry) {
-    const dom::Note& note = noteGeometry->note();
-    if (!note.notations)
-        return;
     
-    const auto& notations = note.notations;
-
-    // Build ties
-    for (auto& tie : notations->ties) {
-        auto key = std::make_pair(note.staff(), note.pitch.get());
-        if (tie->type() == dom::kStart) {
-            _tieStartGeometries[key] = {tie.get(), noteGeometry};
-        } else if (tie->type() == dom::kContinue) {
-            buildTieGeometry(key, *noteGeometry, *tie);
-            _tieStartGeometries[key] = {tie.get(), noteGeometry};
-        } else if (tie->type() == dom::kStop) {
-            buildTieGeometry(key, *noteGeometry, *tie);
+    std::unique_ptr<TieGeometry> TieGeometryFactory::buildTieGeometry(const NoteGeometry* start, const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
+        std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
+        
+        Point startLocation;
+        startLocation.x = start->frame().max().x;
+        startLocation.y = start->center().y;
+        
+        Point stopLocation;
+        stopLocation.x = stop->frame().min().x;
+        stopLocation.y = stop->center().y;
+        
+        if (!placement.isPresent()) {
+            coord_t startStaffY = startLocation.y - _metrics.staffOrigin(start->note().staff());
+            coord_t stopStaffY = stopLocation.y - _metrics.staffOrigin(stop->note().staff());
+            coord_t avgy = (startStaffY + stopStaffY) / 2;
+            if (avgy < Metrics::staffHeight()/2)
+                tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+            else
+                tieGeom->setPlacement(absentOptional(dom::Placement::Below));
         }
-    }
-
-    // Build slurs
-    for (auto& slur : notations->slurs) {
-        auto key = std::make_pair(note.staff(), slur->number());
-        if (slur->type() == dom::kStart) {
-            _slurStartGeometries[key] = {slur.get(), noteGeometry};
-        } else if (slur->type() == dom::kContinue) {
-            buildSlurGeometry(key, *noteGeometry, *slur);
-            _slurStartGeometries[key] = {slur.get(), noteGeometry};
-        } else if (slur->type() == dom::kStop) {
-            buildSlurGeometry(key, *noteGeometry, *slur);
-        }
-    }
-}
-
-void TieGeometryFactory::buildTieGeometry(const PitchKey& key, NoteGeometry& noteGeometry, const dom::Tied& tie) {
-    auto it = _tieStartGeometries.find(key);
-    auto startGeom = it->second.second;
-
-    std::unique_ptr<TieGeometry> tieGeom;
-    if (it == _tieStartGeometries.end()) {
-        if (_metrics.scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
-            tieGeom = buildTieGeometryFromEdge(&noteGeometry, tie.placement());
+        
+        if (tieGeom->placement().value() == dom::Placement::Below) {
+            startLocation.y = start->frame().max().y;
+            stopLocation.y = stop->frame().max().y;
         } else {
-            return;
+            startLocation.y = start->frame().min().y;
+            stopLocation.y = stop->frame().min().y;
         }
-    } else {
-        tieGeom = buildTieGeometry(startGeom, &noteGeometry, tie.placement());
-        startGeom->setTieGeometry(tieGeom.get());
-        _tieStartGeometries.erase(it);
+        
+        tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
+        tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
+        
+        return tieGeom;
     }
-    noteGeometry.setTieGeometry(tieGeom.get());
-    _tieGeometries.push_back(std::move(tieGeom));
-}
-
-void TieGeometryFactory::buildSlurGeometry(const SlurKey& key, NoteGeometry& noteGeometry, const dom::Slur& slur) {
-    auto it = _slurStartGeometries.find(key);
-    auto startGeom = it->second.second;
-
-    std::unique_ptr<TieGeometry> slurGeom;
-    if (it == _slurStartGeometries.end()) {
-        if (_metrics.scoreProperties().layoutType() == ScoreProperties::LayoutType::Page) {
-            slurGeom = buildSlurGeometryFromEdge(&noteGeometry, slur.placement());
+    
+    std::unique_ptr<TieGeometry> TieGeometryFactory::buildTieGeometryFromEdge(const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
+        std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
+        
+        const Geometry* startGeometry = nullptr;
+        std::vector<std::type_index> types = {std::type_index(typeid(KeyGeometry)), std::type_index(typeid(ClefGeometry))};
+        
+        coord_t stopX = stop->convertToGeometry(stop->frame().min(), &_parentGeometry).x;
+        _parentGeometry.lookUpGeometriesWithTypes(types, [&startGeometry, stopX](const Geometry* geometry){
+            if (!startGeometry || (geometry->frame().max().x < stopX && geometry->frame().max().x > startGeometry->frame().max().x))
+                startGeometry = geometry;
+        });
+        
+        Point startLocation;
+        startLocation.x = startGeometry->convertToGeometry(startGeometry->bounds().max(), stop->parentGeometry()).x;
+        startLocation.y = stop->center().y;
+        
+        Point stopLocation;
+        stopLocation.x = stop->frame().min().x;
+        stopLocation.y = stop->center().y;
+        
+        if (!placement.isPresent()) {
+            coord_t staffY = startLocation.y - _metrics.staffOrigin(stop->note().staff());
+            if (staffY < Metrics::staffHeight()/2)
+                tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+            else
+                tieGeom->setPlacement(absentOptional(dom::Placement::Below));
+        }
+        
+        if (tieGeom->placement().value() == dom::Placement::Below) {
+            stopLocation.y = stop->frame().max().y;
         } else {
-            return;
+            stopLocation.y = stop->frame().min().y;
         }
-    } else {
-        slurGeom = buildSlurGeometry(startGeom, &noteGeometry, slur.placement());
-        startGeom->setTieGeometry(slurGeom.get());
-        _slurStartGeometries.erase(it);
-    }
-    noteGeometry.setTieGeometry(slurGeom.get());
-    _tieGeometries.push_back(std::move(slurGeom));
-}
-
-std::unique_ptr<TieGeometry> TieGeometryFactory::buildTieGeometry(const NoteGeometry* start, const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
-    std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
-    
-    Point startLocation;
-    startLocation.x = start->frame().max().x;
-    startLocation.y = start->center().y;
-
-    Point stopLocation;
-    stopLocation.x = stop->frame().min().x;
-    stopLocation.y = stop->center().y;
-
-    if (!placement.isPresent()) {
-        coord_t startStaffY = startLocation.y - _metrics.staffOrigin(start->note().staff());
-        coord_t stopStaffY = stopLocation.y - _metrics.staffOrigin(stop->note().staff());
-        coord_t avgy = (startStaffY + stopStaffY) / 2;
-        if (avgy < Metrics::staffHeight()/2)
-            tieGeom->setPlacement(absentOptional(dom::Placement::Above));
-        else
-            tieGeom->setPlacement(absentOptional(dom::Placement::Below));
+        startLocation.y = stopLocation.y;
+        
+        tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, stop->parentGeometry()));
+        tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
+        
+        return tieGeom;
     }
     
-    if (tieGeom->placement().value() == dom::Placement::Below) {
-        startLocation.y = start->frame().max().y;
-        stopLocation.y = stop->frame().max().y;
-    } else {
-        startLocation.y = start->frame().min().y;
-        stopLocation.y = stop->frame().min().y;
-    }
-
-    tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
-    tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
-    
-    return tieGeom;
-}
-
-std::unique_ptr<TieGeometry> TieGeometryFactory::buildTieGeometryFromEdge(const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
-    std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
-
-    const Geometry* startGeometry = nullptr;
-    std::vector<std::type_index> types = {std::type_index(typeid(KeyGeometry)), std::type_index(typeid(ClefGeometry))};
-
-    coord_t stopX = stop->convertToGeometry(stop->frame().min(), &_parentGeometry).x;
-    _parentGeometry.lookUpGeometriesWithTypes(types, [&startGeometry, stopX](const Geometry* geometry){
-        if (!startGeometry || (geometry->frame().max().x < stopX && geometry->frame().max().x > startGeometry->frame().max().x))
-            startGeometry = geometry;
-    });
-
-    Point startLocation;
-    startLocation.x = startGeometry->convertToGeometry(startGeometry->bounds().max(), stop->parentGeometry()).x;
-    startLocation.y = stop->center().y;
-
-    Point stopLocation;
-    stopLocation.x = stop->frame().min().x;
-    stopLocation.y = stop->center().y;
-
-    if (!placement.isPresent()) {
-        coord_t staffY = startLocation.y - _metrics.staffOrigin(stop->note().staff());
-        if (staffY < Metrics::staffHeight()/2)
-            tieGeom->setPlacement(absentOptional(dom::Placement::Above));
-        else
-            tieGeom->setPlacement(absentOptional(dom::Placement::Below));
-    }
-
-    if (tieGeom->placement().value() == dom::Placement::Below) {
-        stopLocation.y = stop->frame().max().y;
-    } else {
-        stopLocation.y = stop->frame().min().y;
-    }
-    startLocation.y = stopLocation.y;
-
-    tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, stop->parentGeometry()));
-    tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
-    
-    return tieGeom;
-}
-
-std::unique_ptr<TieGeometry> TieGeometryFactory::buildTieGeometryToEdge(const NoteGeometry* start, const dom::Optional<dom::Placement>& placement) {
-    std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
-
-    Point startLocation;
-    startLocation.x = start->frame().max().x;
-    startLocation.y = start->center().y;
-
-    Point stopLocation;
-    stopLocation.x = start->convertFromGeometry(_parentGeometry.bounds().max(), &_parentGeometry).x;
-    stopLocation.x += start->frame().origin.x - kTieSpacing;
-    stopLocation.y = start->center().y;
-
-    if (!placement.isPresent()) {
-        coord_t staffY = startLocation.y - _metrics.staffOrigin(start->note().staff());
-        if (staffY < Metrics::staffHeight()/2)
-            tieGeom->setPlacement(absentOptional(dom::Placement::Above));
-        else
-            tieGeom->setPlacement(absentOptional(dom::Placement::Below));
-    }
-
-    if (tieGeom->placement().value() == dom::Placement::Below) {
-        startLocation.y = start->frame().max().y;
-    } else {
-        startLocation.y = start->frame().min().y;
-    }
-    stopLocation.y = startLocation.y;
-
-    tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
-    tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, start->parentGeometry()));
-    
-    return tieGeom;
-}
-
-
-std::unique_ptr<TieGeometry> TieGeometryFactory::buildSlurGeometryFromEdge(const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
-    std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
-
-    const Geometry* startGeometry = nullptr;
-    std::vector<std::type_index> types = {std::type_index(typeid(KeyGeometry)), std::type_index(typeid(ClefGeometry))};
-
-    coord_t stopX = stop->convertToGeometry(stop->frame().min(), &_parentGeometry).x;
-    _parentGeometry.lookUpGeometriesWithTypes(types, [&startGeometry, stopX](const Geometry* geometry){
-        if (!startGeometry || (geometry->frame().max().x < stopX && geometry->frame().max().x > startGeometry->frame().max().x))
-            startGeometry = geometry;
-    });
-
-    Point startLocation;
-    startLocation.x = startGeometry->convertToGeometry(startGeometry->bounds().max(), stop->parentGeometry()).x + kTieSpacing;
-    startLocation.y = stop->center().y;
-
-    Point stopLocation = stop->location();
-    stopLocation.x -= kTieSpacing;
-
-    const ChordGeometry& stopChordGeom = static_cast<const ChordGeometry&>(*stop->parentGeometry());
-
-    if (!placement.isPresent()) {
-        auto stem = stopChordGeom.stem();
-        if (stem && stem->stemDirection() == dom::Stem::Up)
-            tieGeom->setPlacement(absentOptional(dom::Placement::Below));
-        else
-            tieGeom->setPlacement(absentOptional(dom::Placement::Above));
-    }
-
-    Rect stopChordFrame = stopChordGeom.frame();
-
-    // Correctly place slur using depending on the stem direction
-    if (tieGeom->placement().value() == dom::Placement::Below) {
-        if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Down) {
-            stopLocation.y = stopChordFrame.max().y - kSlurStemOffset;
+    std::unique_ptr<TieGeometry> TieGeometryFactory::buildTieGeometryToEdge(const NoteGeometry* start, const dom::Optional<dom::Placement>& placement) {
+        std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
+        
+        Point startLocation;
+        startLocation.x = start->frame().max().x;
+        startLocation.y = start->center().y;
+        
+        Point stopLocation;
+        stopLocation.x = start->convertFromGeometry(_parentGeometry.bounds().max(), &_parentGeometry).x;
+        stopLocation.x += start->frame().origin.x - kTieSpacing;
+        stopLocation.y = start->center().y;
+        
+        if (!placement.isPresent()) {
+            coord_t staffY = startLocation.y - _metrics.staffOrigin(start->note().staff());
+            if (staffY < Metrics::staffHeight()/2)
+                tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+            else
+                tieGeom->setPlacement(absentOptional(dom::Placement::Below));
+        }
+        
+        if (tieGeom->placement().value() == dom::Placement::Below) {
+            startLocation.y = start->frame().max().y;
         } else {
-            stopLocation.y = stopChordFrame.max().y + kTieSpacing;
+            startLocation.y = start->frame().min().y;
         }
-    } else {
-        if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Up) {
-            stopLocation.y = stopChordFrame.min().y + kSlurStemOffset;
-        } else {
-            stopLocation.y = stopChordFrame.min().y - kTieSpacing;
-        }
-    }
-    startLocation.y = stopLocation.y;
-
-    tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, stop->parentGeometry()));
-    tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
-
-    return tieGeom;
-}
-
-std::unique_ptr<TieGeometry> TieGeometryFactory::buildSlurGeometryToEdge(const NoteGeometry* start, const dom::Optional<dom::Placement>& placement) {
-    std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
-
-    Point startLocation = start->location();
-    startLocation.x += kTieSpacing;
-
-    Point stopLocation;
-    stopLocation.x = start->convertFromGeometry(_parentGeometry.bounds().max(), &_parentGeometry).x;
-    stopLocation.x += start->frame().origin.x - kTieSpacing;
-    stopLocation.y = start->center().y;
-
-
-    const ChordGeometry& startChordGeom = static_cast<const ChordGeometry&>(*start->parentGeometry());
-
-    if (!placement.isPresent()) {
-        auto stem = startChordGeom.stem();
-        if (stem && stem->stemDirection() == dom::Stem::Up)
-            tieGeom->setPlacement(absentOptional(dom::Placement::Below));
-        else
-            tieGeom->setPlacement(absentOptional(dom::Placement::Above));
-    }
-
-    Rect startChordFrame = startChordGeom.frame();
-
-    // Correctly place slur using depending on the stem direction
-    if (tieGeom->placement().value() == dom::Placement::Below) {
-        if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Down) {
-            startLocation.y = startChordFrame.max().y - kSlurStemOffset;
-            startLocation.x = start->frame().max().x - kTieSpacing;
-        } else {
-            startLocation.y = startChordFrame.max().y + kTieSpacing;
-        }
-    } else {
-        if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Up) {
-            startLocation.y = startChordFrame.min().y + kSlurStemOffset;
-            startLocation.x = start->frame().max().x + kTieSpacing;
-        } else {
-            startLocation.y = startChordFrame.min().y - kTieSpacing;
-        }
-    }
-    stopLocation.y = startLocation.y;
-
-    tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
-    tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, start->parentGeometry()));
-    
-    return tieGeom;
-}
-
-std::unique_ptr<TieGeometry> TieGeometryFactory::buildSlurGeometry(const NoteGeometry* start, const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
-    std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
-    
-    Point startLocation = start->location();
-    Point stopLocation = stop->location();
-    
-    startLocation.x += kTieSpacing;
-    stopLocation.x -= kTieSpacing;
-
-    const ChordGeometry& startChordGeom = static_cast<const ChordGeometry&>(*start->parentGeometry());
-    const ChordGeometry& stopChordGeom = static_cast<const ChordGeometry&>(*stop->parentGeometry());
-
-    if (!placement.isPresent()) {
-        auto s1 = startChordGeom.stem();
-        auto s2 = stopChordGeom.stem();
-
-        if (s1 && s1->stemDirection() == dom::Stem::Up && s2 && s2->stemDirection() == dom::Stem::Up)
-            tieGeom->setPlacement(absentOptional(dom::Placement::Below));
-        else
-            tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+        stopLocation.y = startLocation.y;
+        
+        tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
+        tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, start->parentGeometry()));
+        
+        return tieGeom;
     }
     
-    Rect startChordFrame = startChordGeom.frame();
-    Rect stopChordFrame = stopChordGeom.frame();
-
-    // Correctly place slur using depending on the stem direction
-    if (tieGeom->placement().value() == dom::Placement::Below) {
-        if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Down) {
-            startLocation.y = startChordFrame.max().y - kSlurStemOffset;
-            startLocation.x = start->frame().max().x - kTieSpacing;
-        } else {
-            startLocation.y = startChordFrame.max().y + kTieSpacing;
-        }
-        if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Down) {
-            stopLocation.y = stopChordFrame.max().y - kSlurStemOffset;
-            startLocation.x = start->frame().max().x + kTieSpacing;
-        } else {
-            stopLocation.y = stopChordFrame.max().y + kTieSpacing;
-        }
-    } else {
-        if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Up) {
-            startLocation.y = startChordFrame.min().y + kSlurStemOffset;
-            startLocation.x = start->frame().max().x + kTieSpacing;
-        } else {
-            startLocation.y = startChordFrame.min().y - kTieSpacing;
-        }
-        if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Up) {
-            stopLocation.y = stopChordFrame.min().y + kSlurStemOffset;
-            startLocation.x = start->frame().max().x + kTieSpacing;
-        } else {
-            stopLocation.y = stopChordFrame.min().y - kTieSpacing;
-        }
-    }
-
-    tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
-    tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
     
-    return tieGeom;
-}
-
+    std::unique_ptr<TieGeometry> TieGeometryFactory::buildSlurGeometryFromEdge(const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
+        std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
+        
+        const Geometry* startGeometry = nullptr;
+        std::vector<std::type_index> types = {std::type_index(typeid(KeyGeometry)), std::type_index(typeid(ClefGeometry))};
+        
+        coord_t stopX = stop->convertToGeometry(stop->frame().min(), &_parentGeometry).x;
+        _parentGeometry.lookUpGeometriesWithTypes(types, [&startGeometry, stopX](const Geometry* geometry){
+            if (!startGeometry || (geometry->frame().max().x < stopX && geometry->frame().max().x > startGeometry->frame().max().x))
+                startGeometry = geometry;
+        });
+        
+        Point startLocation;
+        startLocation.x = startGeometry->convertToGeometry(startGeometry->bounds().max(), stop->parentGeometry()).x + kTieSpacing;
+        startLocation.y = stop->center().y;
+        
+        Point stopLocation = stop->location();
+        stopLocation.x -= kTieSpacing;
+        
+        const ChordGeometry& stopChordGeom = static_cast<const ChordGeometry&>(*stop->parentGeometry());
+        
+        if (!placement.isPresent()) {
+            auto stem = stopChordGeom.stem();
+            if (stem && stem->stemDirection() == dom::Stem::Up)
+                tieGeom->setPlacement(absentOptional(dom::Placement::Below));
+            else
+                tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+        }
+        
+        Rect stopChordFrame = stopChordGeom.frame();
+        
+        // Correctly place slur using depending on the stem direction
+        if (tieGeom->placement().value() == dom::Placement::Below) {
+            if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Down) {
+                stopLocation.y = stopChordFrame.max().y - kSlurStemOffset;
+            } else {
+                stopLocation.y = stopChordFrame.max().y + kTieSpacing;
+            }
+        } else {
+            if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Up) {
+                stopLocation.y = stopChordFrame.min().y + kSlurStemOffset;
+            } else {
+                stopLocation.y = stopChordFrame.min().y - kTieSpacing;
+            }
+        }
+        startLocation.y = stopLocation.y;
+        
+        tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, stop->parentGeometry()));
+        tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
+        
+        return tieGeom;
+    }
+    
+    std::unique_ptr<TieGeometry> TieGeometryFactory::buildSlurGeometryToEdge(const NoteGeometry* start, const dom::Optional<dom::Placement>& placement) {
+        std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
+        
+        Point startLocation = start->location();
+        startLocation.x += kTieSpacing;
+        
+        Point stopLocation;
+        stopLocation.x = start->convertFromGeometry(_parentGeometry.bounds().max(), &_parentGeometry).x;
+        stopLocation.x += start->frame().origin.x - kTieSpacing;
+        stopLocation.y = start->center().y;
+        
+        
+        const ChordGeometry& startChordGeom = static_cast<const ChordGeometry&>(*start->parentGeometry());
+        
+        if (!placement.isPresent()) {
+            auto stem = startChordGeom.stem();
+            if (stem && stem->stemDirection() == dom::Stem::Up)
+                tieGeom->setPlacement(absentOptional(dom::Placement::Below));
+            else
+                tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+        }
+        
+        Rect startChordFrame = startChordGeom.frame();
+        
+        // Correctly place slur using depending on the stem direction
+        if (tieGeom->placement().value() == dom::Placement::Below) {
+            if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Down) {
+                startLocation.y = startChordFrame.max().y - kSlurStemOffset;
+                startLocation.x = start->frame().max().x - kTieSpacing;
+            } else {
+                startLocation.y = startChordFrame.max().y + kTieSpacing;
+            }
+        } else {
+            if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Up) {
+                startLocation.y = startChordFrame.min().y + kSlurStemOffset;
+                startLocation.x = start->frame().max().x + kTieSpacing;
+            } else {
+                startLocation.y = startChordFrame.min().y - kTieSpacing;
+            }
+        }
+        stopLocation.y = startLocation.y;
+        
+        tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
+        tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, start->parentGeometry()));
+        
+        return tieGeom;
+    }
+    
+    std::unique_ptr<TieGeometry> TieGeometryFactory::buildSlurGeometry(const NoteGeometry* start, const NoteGeometry* stop, const dom::Optional<dom::Placement>& placement) {
+        std::unique_ptr<TieGeometry> tieGeom(new TieGeometry);
+        
+        Point startLocation = start->location();
+        Point stopLocation = stop->location();
+        
+        startLocation.x += kTieSpacing;
+        stopLocation.x -= kTieSpacing;
+        
+        const ChordGeometry& startChordGeom = static_cast<const ChordGeometry&>(*start->parentGeometry());
+        const ChordGeometry& stopChordGeom = static_cast<const ChordGeometry&>(*stop->parentGeometry());
+        
+        if (!placement.isPresent()) {
+            auto s1 = startChordGeom.stem();
+            auto s2 = stopChordGeom.stem();
+            
+            if (s1 && s1->stemDirection() == dom::Stem::Up && s2 && s2->stemDirection() == dom::Stem::Up)
+                tieGeom->setPlacement(absentOptional(dom::Placement::Below));
+            else
+                tieGeom->setPlacement(absentOptional(dom::Placement::Above));
+        }
+        
+        Rect startChordFrame = startChordGeom.frame();
+        Rect stopChordFrame = stopChordGeom.frame();
+        
+        // Correctly place slur using depending on the stem direction
+        if (tieGeom->placement().value() == dom::Placement::Below) {
+            if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Down) {
+                startLocation.y = startChordFrame.max().y - kSlurStemOffset;
+                startLocation.x = start->frame().max().x - kTieSpacing;
+            } else {
+                startLocation.y = startChordFrame.max().y + kTieSpacing;
+            }
+            if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Down) {
+                stopLocation.y = stopChordFrame.max().y - kSlurStemOffset;
+                startLocation.x = start->frame().max().x + kTieSpacing;
+            } else {
+                stopLocation.y = stopChordFrame.max().y + kTieSpacing;
+            }
+        } else {
+            if (startChordGeom.stem() && startChordGeom.stem()->stemDirection() == dom::Stem::Up) {
+                startLocation.y = startChordFrame.min().y + kSlurStemOffset;
+                startLocation.x = start->frame().max().x + kTieSpacing;
+            } else {
+                startLocation.y = startChordFrame.min().y - kTieSpacing;
+            }
+            if (stopChordGeom.stem() && stopChordGeom.stem()->stemDirection() == dom::Stem::Up) {
+                stopLocation.y = stopChordFrame.min().y + kSlurStemOffset;
+                startLocation.x = start->frame().max().x + kTieSpacing;
+            } else {
+                stopLocation.y = stopChordFrame.min().y - kTieSpacing;
+            }
+        }
+        
+        tieGeom->setStartLocation(_parentGeometry.convertFromGeometry(startLocation, start->parentGeometry()));
+        tieGeom->setStopLocation(_parentGeometry.convertFromGeometry(stopLocation, stop->parentGeometry()));
+        
+        return tieGeom;
+    }
+    
 } // namespace mxml


### PR DESCRIPTION
Ties often render improperly in ScrollScoreLayout because TieFactory assumes a page layout, and therefore renders ties as if there were multiple systems. This creates lots of super long ties that cover up the rest of the sheet music. This PR fixes this behavior. 